### PR TITLE
Deploy dependencies in the AppImage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,9 @@ cd "${APP_DIR}"
 # bundle all libs
 mkdir -p ./usr/lib
 ldd ./usr/bin/ghostty | awk -F"[> ]" '{print $4}' | xargs -I {} cp -vn {} ./usr/lib
-mv ./usr/lib/ld-linux-x86-64.so.2 ./
+if ! mv ./usr/lib/ld-linux-x86-64.so.2 ./; then
+	cp -v /lib64/ld-linux-x86-64.so.2 ./
+fi
 
 # prep appimage
 echo '#!/usr/bin/env sh

--- a/build.sh
+++ b/build.sh
@@ -44,8 +44,15 @@ zig build \
 
 cd "${APP_DIR}"
 
+# bundle all libs
+mkdir -p ./usr/lib
+ldd ./usr/bin/ghostty | awk -F"[> ]" '{print $4}' | xargs -I {} cp -vn {} ./usr/lib
+mv ./usr/lib/ld-linux-x86-64.so.2 ./
+
 # prep appimage
-printf '#!/bin/sh\n\nexec "$(dirname "$(readlink -f "$0")")/usr/bin/ghostty"\n' | tee AppRun >/dev/null
+echo '#!/usr/bin/env sh
+HERE="$(dirname "$(readlink -f "$0")")"
+exec "$HERE"/ld-linux-x86-64.so.2 --library-path "$HERE"/usr/lib "$HERE"/usr/bin/ghostty "$@"' > ./AppDir/AppRun
 chmod +x AppRun
 ln -s usr/share/applications/com.mitchellh.ghostty.desktop
 ln -s usr/share/icons/hicolor/256x256/apps/com.mitchellh.ghostty.png

--- a/build.sh
+++ b/build.sh
@@ -54,13 +54,13 @@ fi
 # prep appimage
 echo '#!/usr/bin/env sh
 HERE="$(dirname "$(readlink -f "$0")")"
-exec "$HERE"/ld-linux-x86-64.so.2 --library-path "$HERE"/usr/lib "$HERE"/usr/bin/ghostty "$@"' > ./AppDir/AppRun
+exec "$HERE"/ld-linux-x86-64.so.2 --library-path "$HERE"/usr/lib "$HERE"/usr/bin/ghostty "$@"' > ./AppRun
 chmod +x AppRun
 ln -s usr/share/applications/com.mitchellh.ghostty.desktop
 ln -s usr/share/icons/hicolor/256x256/apps/com.mitchellh.ghostty.png
 
 cd "${TMP_DIR}"
 # create app image
-ARCH=x8_64 appimagetool "${APP_DIR}"
+ARCH="$(uname -m)" appimagetool "${APP_DIR}"
 
 appimagelint "${TMP_DIR}/Ghostty-x86_64.AppImage" || true

--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,7 @@ fi
 # prep appimage
 echo '#!/usr/bin/env sh
 HERE="$(dirname "$(readlink -f "$0")")"
+export TERM=xterm-256color
 exec "$HERE"/ld-linux-x86-64.so.2 --library-path "$HERE"/usr/lib "$HERE"/usr/bin/ghostty "$@"' > ./AppRun
 chmod +x AppRun
 ln -s usr/share/applications/com.mitchellh.ghostty.desktop


### PR DESCRIPTION
The current AppImage doesn't work on my Artix linux system since I don't have `libonig.so.5`, I also don't have GTK4 and a bunch other libraries needed

These changes truly make the appimage work on any linux system, it even runs on the alpine linux container that I have (no glibc).

![image](https://github.com/user-attachments/assets/b75db981-6fe0-428a-b1db-5a81771b127b)

I still have a missing icon on the top left of the screen though 🤔

Please remember to squash and merge to avoid cluttering the commit history with the comments I made lol


