### PR TITLE
Add zizmor linter and resolve warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,13 +8,12 @@ on:
   release:
     types: [published]
 
-permissions:
-  actions: read
-  security-events: write
-  contents: write
-
 jobs:
   build_appimage:
+    permissions:
+      actions: read
+      security-events: write
+      contents: write
     name: Build Ghostty
     runs-on: ubuntu-24.04
     container:
@@ -23,6 +22,8 @@ jobs:
     steps:
       - name: Checkout ghostty-appimage
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Build Env
         run: ./setup.sh
@@ -38,6 +39,10 @@ jobs:
           path: /tmp/ghostty-build/Ghostty-x86_64.AppImage
 
   release_appimage:
+    permissions:
+      actions: read
+      security-events: write
+      contents: write
     name: "Upload binaries to current release"
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'release' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,9 @@ repos:
     rev: v1.7.6
     hooks:
       - id: actionlint-system
+
+  - repo: https://github.com/woodruffw/zizmor
+    rev: v0.5.0
+    hooks:
+      - id: zizmor
+        files: ^\.github/workflows/.*\.ya?ml$


### PR DESCRIPTION
I see you are using pre-commit. I suggest you add zizmor as another linter for GHA.

Why did you chose to use `- id: actionlint-system`  instead of `- id: actionlint`?