### PR TITLE
set `$VERSION` variable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           name: ghostty-appimage
           retention-days: 7
-          path: /tmp/ghostty-build/Ghostty-x86_64.AppImage*
+          path: /tmp/ghostty-build/Ghostty-*-x86_64.AppImage*
 
   release_appimage:
     permissions:
@@ -56,7 +56,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./Ghostty-x86_64.AppImage*
+          file: ./Ghostty-*-x86_64.AppImage*
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/build.sh
+++ b/build.sh
@@ -80,6 +80,12 @@ EOF
 
 chmod +x AppRun
 
+export VERSION="$(./AppRun --version 2>/dev/null | awk 'FNR==1 {print $2}')"
+if [ -z "$VERSION" ]; then
+	echo "ERROR: Could not get version from ghostty binary"
+	exit 1
+fi
+
 cp "${APPDATA_FILE}" "usr/share/metainfo/com.mitchellh.ghostty.appdata.xml"
 
 # Fix Gnome dock issues -- StartupWMClass attribute needs to be present.


### PR DESCRIPTION
[Recommended](https://github.com/AppImage/AppImageSpec/blob/master/draft.md#type-2-image-format) by the AppImage spec.

`appimagetool` checks this variable and adds it to the title of the AppImage.

This also doubles as a test that prevents releasing a broken AppImage if something goes wrong since in that case the variable turns empty.