### PR TITLE
add libpthread.so.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,7 @@ cd "${APP_DIR}"
 
 # bundle all libs
 ldd ./usr/bin/ghostty | awk -F"[> ]" '{print $4}' | xargs -I {} cp --update=none -v {} ./usr/lib
+cp -v /usr/lib/x86_64-linux-gnu/libpthread.so.0 ./usr/lib
 if ! mv ./usr/lib/ld-linux-x86-64.so.2 ./; then
 	cp -v /lib64/ld-linux-x86-64.so.2 ./
 fi


### PR DESCRIPTION
Noticed the issue you ran into at appimagehub.

What's crazy is that the current appimage works on voidlinux musl, which is a fully incompatible environment lol. 

However this doesn't fix the problem fully, on 20.04 you will now have a different error about opengl, seems like the appimage needs a new version of opengl to work which ubuntu 20.04 doesn't provide. 

We can bundle opengl, and that's something I usually do, however that means the size will increase to 100 MiB.

