### PR TITLE
unset `ARGV0`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,6 +88,7 @@ cat <<'EOF' >./AppRun
 #!/usr/bin/env sh
 
 HERE="$(dirname "$(readlink -f "$0")")"
+unset ARGV0
 
 export TERM=xterm-256color
 export GHOSTTY_RESOURCES_DIR="${HERE}/usr/share/ghostty"


### PR DESCRIPTION
Fixes issues with zsh users, see: https://github.com/AppImage/AppImageKit/issues/852

Fixes #20