### PR TITLE
ci: build base image and setup

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,65 @@
+name: Build Image
+on:
+  workflow_dispatch: {}
+  push:
+    paths:
+      - "Dockerfile"
+      - "setup.sh"
+
+jobs:
+  buid_base_image:
+    name: 👻 Build Ghossty Base Image
+    permissions:
+      actions: read
+      security-events: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debloat Runner
+        run: |
+          set +x ; set +e
+          bash <(curl -qfsSL "https://raw.githubusercontent.com/pkgforge/devscripts/refs/heads/main/Github/Runners/debloat_ubuntu.sh")
+        continue-on-error: true
+
+      - name: Checkout ghostty-appimage
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Env
+        run: |
+          set +x ; set +e
+          DOCKER_TAG="v$(date +'%Y.%m.%d')" && export DOCKER_TAG="$DOCKER_TAG"
+          echo "DOCKER_TAG=$DOCKER_TAG" >> "${GITHUB_ENV}"
+          echo "GHCR_NAME=ghcr.io/${{ github.repository_owner }}/ghostty-base" >> "${GITHUB_ENV}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        continue-on-error: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        continue-on-error: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: "${{ secrets.DOCKER_USERNAME }}"
+          password: "${{ secrets.DOCKER_PASSWORD }}"
+        continue-on-error: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.ref_name == 'main' }}
+          platforms: "linux/amd64,linux/arm64"
+          tags: |
+            ${{ env.GHCR_NAME }}:latest
+            ${{ env.GHCR_NAME }}:${{ env.DOCKER_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/pkgforge-dev/archlinux:latest
+
+COPY setup.sh setup.sh
+
+RUN sh setup.sh


### PR DESCRIPTION
use docker image with all the dependencies installed through setup.sh,
avoids performing setup for run, reduced resource usage and the overall
build time.
