### PR TITLE
Switch to uruntime

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -99,4 +99,10 @@ fi
 cd "${TMP_DIR}"
 
 # create app image
+URUNTIME_URL="${GITHUB_BASE}/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-${ARCH}"
+if [ ! -f '/usr/local/bin/uruntime' ]; then
+	wget "${URUNTIME_URL}" -O /usr/local/bin/uruntime
+	chmod +x /usr/local/bin/uruntime
+fi
+
 appimagetool -u "${UPINFO}" "${APP_DIR}" --runtime-file /usr/local/bin/uruntime

--- a/build.sh
+++ b/build.sh
@@ -99,4 +99,4 @@ fi
 cd "${TMP_DIR}"
 
 # create app image
-appimagetool -u "${UPINFO}" "${APP_DIR}"
+appimagetool -u "${UPINFO}" "${APP_DIR}" --runtime-file /usr/local/bin/uruntime

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ fi
 cd "${TMP_DIR}"
 
 # create app image
-URUNTIME_URL="${GITHUB_BASE}/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-${ARCH}"
+URUNTIME_URL="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-${ARCH}"
 if [ ! -f '/usr/local/bin/uruntime' ]; then
 	wget "${URUNTIME_URL}" -O /usr/local/bin/uruntime
 	chmod +x /usr/local/bin/uruntime

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ LLVM_BASE="${GITHUB_BASE}/pkgforge-dev/llvm-libs-debloated/releases/download/con
 ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz"
 LIB4BIN_URL="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
 SHARUN_URL="${GITHUB_BASE}/VHSgunzo/sharun/releases/download/${SHARUN_VERSION}/sharun-${ARCH}"
-URUNTIME_URL="${GITHUB_BASE}/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-lite-${ARCH}"
+URUNTIME_URL="${GITHUB_BASE}/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-${ARCH}"
 
 case "${ARCH}" in
 "x86_64")

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,7 @@ LLVM_BASE="${GITHUB_BASE}/pkgforge-dev/llvm-libs-debloated/releases/download/con
 ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz"
 LIB4BIN_URL="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
 SHARUN_URL="${GITHUB_BASE}/VHSgunzo/sharun/releases/download/${SHARUN_VERSION}/sharun-${ARCH}"
+URUNTIME_URL="${GITHUB_BASE}/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-lite-${ARCH}"
 
 case "${ARCH}" in
 "x86_64")
@@ -83,6 +84,12 @@ fi
 if [ ! -f '/usr/local/bin/sharun' ]; then
 	wget "${SHARUN_URL}" -O /usr/local/bin/sharun
 	chmod +x /usr/local/bin/sharun
+fi
+
+if [ ! -f '/usr/local/bin/uruntime' ]; then
+	wget "${URUNTIME_URL}" -O /tmp/uruntime
+	chmod +x /tmp/uruntime
+	mv /tmp/uruntime /usr/local/bin/uruntime
 fi
 
 if [ ! -f '/opt/path-mapping.so' ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -87,9 +87,8 @@ if [ ! -f '/usr/local/bin/sharun' ]; then
 fi
 
 if [ ! -f '/usr/local/bin/uruntime' ]; then
-	wget "${URUNTIME_URL}" -O /tmp/uruntime
-	chmod +x /tmp/uruntime
-	mv /tmp/uruntime /usr/local/bin/uruntime
+	wget "${URUNTIME_URL}" -O /usr/local/bin/uruntime
+	chmod +x /usr/local/bin/uruntime
 fi
 
 if [ ! -f '/opt/path-mapping.so' ]; then


### PR DESCRIPTION
By default this will try to use FUSE to mount the AppImage, if that fails it will fallback to extract and run, this way the AppImage is guaranteed to always work on any system. 

We also get the advantage that the uruntime is slightly faster than the type2 runtime we launched normally with fuse. 

NOTE: I cannot get the CI to work because I get this error: 

`Error: buildx failed with: ERROR: invalid tag "ghcr.io/Samueru-sama/ghostty-appimage:latest": repository name must be lowercase`
