### PR TITLE
increase block size and compression level

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -101,6 +101,6 @@ cd "${TMP_DIR}"
 
 # create app image
 appimagetool --comp zstd \
-        --mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
-        --mksquashfs-opt -b --mksquashfs-opt 1M \
+	--mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+	--mksquashfs-opt -b --mksquashfs-opt 1M \
 	-u "${UPINFO}" "${APP_DIR}" --runtime-file /usr/local/bin/uruntime

--- a/build.sh
+++ b/build.sh
@@ -100,4 +100,7 @@ fi
 cd "${TMP_DIR}"
 
 # create app image
-appimagetool -u "${UPINFO}" "${APP_DIR}" --runtime-file /usr/local/bin/uruntime
+appimagetool --comp zstd \
+        --mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+        --mksquashfs-opt -b --mksquashfs-opt 1M \
+	-u "${UPINFO}" "${APP_DIR}" --runtime-file /usr/local/bin/uruntime


### PR DESCRIPTION
This makes the AppImage 71 MiB while increasing the launch time of the very first run by 150ms, since the uruntime is kept mounted it only affects the first launch.

![image](https://github.com/user-attachments/assets/2b0e8070-98e2-4b97-a927-450269e3d5b9)
