### PR TITLE
Revert "chore(deps): update softprops/action-gh-release action to v2.3.0"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,7 +181,7 @@ jobs:
           name: ghostty-appimage-x86_64-glfw
 
       - name: Ghostty Tip ("Nightly")
-        uses: softprops/action-gh-release@v2.3.0
+        uses: softprops/action-gh-release@v2.2.2
         with:
           name: '👻 Ghostty Tip ("Nightly")'
           prerelease: true


### PR DESCRIPTION
Reverts pkgforge-dev/ghostty-appimage#80

If not done the next nightly release will be empty. 

See https://github.com/softprops/action-gh-release/issues/628