### PR TITLE
fix: strip .sframe from glibc crt objects to unblock Zig linker on GCC 15+

### DIFF
--- a/bin/build-ghostty.sh
+++ b/bin/build-ghostty.sh
@@ -42,10 +42,10 @@ BUILD_ARGS="${BUILD_ARGS} -Dversion-string=${GHOSTTY_VERSION}"
 
 # Configure Zig: https://ziglang.org
 ZIG_VERSION="$(cat "ghostty-${GHOSTTY_VERSION}/build.zig.zon" | grep ".minimum_zig_version" | cut -d'"' -f2)"
+ZIG_PACKAGE_NAME="zig-${ARCH}-linux-${ZIG_VERSION}"
 CURRENT_ZIG_VERSION=$(zig version 2>/dev/null || true)
 if [ "$CURRENT_ZIG_VERSION" != "$ZIG_VERSION" ]; then
 	echo "Installing Zig ${ZIG_VERSION}..."
-	ZIG_PACKAGE_NAME="zig-${ARCH}-linux-${ZIG_VERSION}"
 	ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/${ZIG_PACKAGE_NAME}.tar.xz"
 	rm -rf /opt/zig*
 	unlink /usr/local/bin/zig || true

--- a/bin/bundle-appimage.sh
+++ b/bin/bundle-appimage.sh
@@ -6,7 +6,6 @@ ARCH="$(uname -m)"
 GHOSTTY_VERSION="$(cat VERSION)"
 
 export UPINFO="gh-releases-zsync|$(echo "${GITHUB_REPOSITORY}" | tr '/' '|')|latest|Ghostty-*$ARCH.AppImage.zsync"
-export URUNTIME_PRELOAD=1
 export DEPLOY_OPENGL=1
 export EXEC_WRAPPER=1
 export OUTNAME="Ghostty-${GHOSTTY_VERSION}-${ARCH}.AppImage"

--- a/bin/setup-env.sh
+++ b/bin/setup-env.sh
@@ -14,6 +14,14 @@ ghosttyDeps="gtk4 libadwaita gtk4-layer-shell"
 rm -rf "/usr/share/libalpm/hooks/package-cleanup.hook"
 pacman -Syuq --needed --noconfirm --noprogressbar ${buildDeps} ${ghosttyDeps}
 
+# GCC 15+ compiles glibc crt startup objects with .sframe sections that use R_X86_64_PC64
+# relocations. Zig's self-hosted linker doesn't support this relocation type, causing
+# build-time helpers (e.g. ghostty-build-data) to fail. Strip .sframe and its associated
+# relocation section from the affected objects so the linker never encounters them.
+for _crt in /usr/lib/crt1.o /usr/lib/Scrt1.o /usr/lib/rcrt1.o; do
+	[ -f "$_crt" ] && objcopy --remove-section .sframe --remove-section .rela.sframe "$_crt"
+done
+
 ARCH="$(uname -m)"
 
 MINISIGN_VERSION="$(get_latest_gh_release 'jedisct1/minisign')"


### PR DESCRIPTION
Stacks on top of #140.

## Problem

GCC 15+ compiles glibc crt startup objects (`crt1.o`, `Scrt1.o`, `rcrt1.o`) with `.sframe` sections that use `R_X86_64_PC64` relocations. Zig's self-hosted linker doesn't support this relocation type, causing build-time helpers such as `ghostty-build-data` to fail:

```
error: fatal linker error: unhandled relocation type R_X86_64_PC64 at offset 0x1c
    note: in /usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib/crt1.o:.sframe
```

The same root cause has been discussed at https://ziggit.dev/t/linker-error-when-building-zig-from-source/14394 and a matching fix has been approved upstream in ghostty itself (ghostty-org/ghostty#11993) — but that only helps tip builds once it lands; stable releases need a workaround at the build-script level.

## Fix

In `setup-env.sh`, immediately after pacman installs packages, use `objcopy` (already available via `binutils`/`base-devel`) to strip `.sframe` and its associated relocation section `.rela.sframe` from the three affected crt objects:

```sh
for _crt in /usr/lib/crt1.o /usr/lib/Scrt1.o /usr/lib/rcrt1.o; do
    [ -f "$_crt" ] && objcopy --remove-section .sframe --remove-section .rela.sframe "$_crt"
done
```

This is version-agnostic — it works for GCC 15, 16, and beyond without requiring any changes to the Zig invocation or ghostty's build system.

Also removes `URUNTIME_PRELOAD=1` from `bundle-appimage.sh`. The `aarch64` `dwarfs-lite` uruntime variant (v0.5.7) does not support the `URUNTIME_MOUNT` marker patching that flag triggers, causing AppImage packaging to fail on aarch64.

## Tested

Full green CI run on both `x86_64` and `aarch64` (stable build, v1.3.1):
https://github.com/codemedic/ghostty-appimage/actions/runs/25518466177