### PR TITLE
fix: disable system freetype stack for appimage build

### DIFF
--- a/bin/build-ghostty.sh
+++ b/bin/build-ghostty.sh
@@ -13,6 +13,9 @@ BUILD_ARGS="
 	-Doptimize=ReleaseFast \
 	-Dpie=true \
     --system /tmp/offline-cache/p \
+    -fno-sys=freetype \
+    -fno-sys=zlib \
+    -fno-sys=libpng \
     -Dgtk-wayland=true \
     -Dgtk-x11=true \
     -Demit-docs=false \


### PR DESCRIPTION
build error/warning (ref: [959](https://github.com/pkgforge-dev/ghostty-appimage/actions/runs/25634049617/job/75242709947#step:6:1960))
```
+ zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dpie=true --system /tmp/offline-cache/p -Dgtk-wayland=true -Dgtk-x11=true -Demit-docs=false -Dstrip=true -Dversion-string=1.3.1
install
+- install ghostty
   +- compile exe ghostty ReleaseFast native-native failure
error: warning(link): unexpected LLD stderr:
ld.lld: warning: .zig-cache/o/0debd203fc5e7fd21b4a6ed9319b6823/libdcimgui.a: archive member '/lib64/libfreetype.so' is neither ET_REL nor LLVM bitcode
ld.lld: warning: .zig-cache/o/0debd203fc5e7fd21b4a6ed9319b6823/libdcimgui.a: archive member '/lib64/libfreetype.so' is neither ET_REL nor LLVM bitcode
```

this PR add `freetype`, `zlib` and `libpng` to   `- -fno-sys` to ensure these three deps now built/linked from Ghostty vendor Zig packages